### PR TITLE
Resolvido problema no botão do menu

### DIFF
--- a/static/stylesheets/menu.css
+++ b/static/stylesheets/menu.css
@@ -45,7 +45,8 @@
 @media (max-width: 992px) {
     #menu .navbar-collapse {
         left: 0;
-        padding: 80px 0 10px 25px;
+        padding: 3px 0 10px 25px;
+        margin-top: 77px;
     }
 
     #menu .nav-link, #menu .dropdown-item {


### PR DESCRIPTION
A div que contém os links estava sobrepondo grande parte do botão, o que dificultava clicá-lo no
vamente para fechar o menu. O espaço estava sendo preenchido com o padding da div, agora o espaço é
criado pela margin, o que não impede o clique dos elementros traseiros. Inclusive este problema afet
ava o clique no logotipo do site que possui a função de ir para a homepage.